### PR TITLE
mods for doc build

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,7 +7,9 @@
     usage
     modal
     utilities
+    references
 
 .. only:: html
 
     * :ref:`genindex`
+    

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1,0 +1,13 @@
+%% Saved with string encoding Unicode (UTF-8) 
+
+
+
+@book{Rafaely2019_book,
+	Author = {Boaz Rafaely},
+	Date-Added = {2021-01-25 1:32:04 PM +0100},
+	Date-Modified = {2021-01-25 1:45:03 PM +0100},
+	Doi = {https://doi.org/10.1007/978-3-319-99561-8},
+	Edition = {2nd},
+	Publisher = {Springer},
+	Title = {Fundamentals of Spherical Array Processing},
+	Year = {2019}}

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -1,0 +1,5 @@
+References
+==========
+
+.. bibliography::
+    :style: alpha

--- a/micarray/modal/angular.py
+++ b/micarray/modal/angular.py
@@ -34,6 +34,8 @@ def sht_matrix(N, azi, colat, weights=None):
     (Note: :math:`\mathbf{Y}` is interpreted as the inverse transform (or synthesis)
     matrix in examples and documentation.)
 
+    cf. eq. (1.9), (3.29) :cite:`Rafaely2019_book`
+
     Parameters
     ----------
     N : int


### PR DESCRIPTION
I updated the sphinx doc build handling since the old handling did not work with recent package versions, at least not on my computer. I also added bib-file handling.

The conf.py file mods originate from taking and adapting the conf.py file from the sfs toolbox project, I am not an expert in this, so please check carefully.

I used a python environment that was created by conda 4.9.2 and
conda create -n mysfa python=3.7.9 numpy=1.19.5 matplotlib=3.3.3 scipy=1.6.0 nbsphinx=0.8.1 sphinxcontrib-bibtex=2.1.4